### PR TITLE
Changed output to govdown_document in skeleton YAML

### DIFF
--- a/docs/inst/rmarkdown/templates/govuk/skeleton/skeleton.Rmd
+++ b/docs/inst/rmarkdown/templates/govuk/skeleton/skeleton.Rmd
@@ -3,7 +3,7 @@ title: "GOV.UK-style R Markdown Document"
 author: ""
 date: ""
 output:
-  govdown::govuk_document
+  govdown::govdown_document
 ---
 
 ## Header level 1 (not a title)


### PR DESCRIPTION
To fix #1  by reflecting the change from `govdown::govuk_document` to `govdown::govdown_document` in the 'output' section of the YAML for the R Markdown template provided with the package.