### PR TITLE
Pass through args to base_format to make compatible with shiny

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: govdown
 Title: GOV.UK Style Templates for R Markdown
-Version: 0.4.1.9000
+Version: 0.4.1.9001
 Authors@R:
     person(given = "Duncan",
            family = "Garmonsway",

--- a/R/govdown-format.R
+++ b/R/govdown-format.R
@@ -104,7 +104,8 @@ govdown_document <- function(keep_md = FALSE,
                              title = "Title",
                              phase = c("none", "alpha", "beta"),
                              feedback_url = "404.html",
-                             google_analytics = NULL) {
+                             google_analytics = NULL,
+                             ...) {
 
   rmarkdown::pandoc_available("2", error = TRUE)
 
@@ -211,7 +212,8 @@ govdown_document <- function(keep_md = FALSE,
                         "--highlight-style=pygments",
                         "--mathjax"
                         ),
-        extra_dependencies = extra_dependencies
+        extra_dependencies = extra_dependencies,
+        ...
       )
   )
 


### PR DESCRIPTION
This makes govdown compatible with being served on a Shiny Server (i.e. dynamically rendered). 

It should close #32 

I think since it's a simple arg pass through  it doesn't break anything - but let me know if something more nuanced is needed.

Do you want me to increment the version number in `DESCRIPTION`?  Does it go to 9001 from 9000?