### PR TITLE
Disable code highlighting

### DIFF
--- a/inst/rmarkdown/resources/govukish.css
+++ b/inst/rmarkdown/resources/govukish.css
@@ -4314,6 +4314,11 @@ pre {
   border: 1px solid #b1b4b6;
   background-color: #f8f8f8; }
 
+pre,
+code {
+  font-family: monospace, monospace;
+  font-size: 1em; }
+
 .sourceCode + .govuk-heading-l, .sourceCode + .govuk-heading-l {
   padding-top: 5px; }
 

--- a/scss/code-block.scss
+++ b/scss/code-block.scss
@@ -8,6 +8,26 @@ pre {
   background-color: #f8f8f8;
 }
 
+// Fix monospace font size when used with relative typography
+//
+// Browsers automatically reduce monospace font size
+//
+// [1] restores the normal text size in Mozilla Firefox, Google Chrome,
+// and Safari; this unusual style rule should also be used anywhere where
+// you would otherwise set the font-family property to ‘monospace’.
+// [2] restores the normal text size in Internet Explorer and Opera.
+//
+// source:
+// http://code.iamkate.com/html-and-css/fixing-browsers-broken-monospace-font-handling/
+//
+// via:
+// https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/main.scss#L130
+pre,
+code {
+  font-family: monospace, monospace; // [1]
+  font-size: 1em; // [2]
+}
+
 .sourceCode + .govuk-heading-l, .sourceCode + .govuk-heading-l {
   padding-top: 5px; }
   @media (min-width: 40.0625em) {


### PR DESCRIPTION
And stop it being shrunk.  This partly addresses #45 by removing highlighting altogether, but eventually we should reinstate highlighting in a better way.