### PR TITLE
Clarify publishing on GOV.UK itself

### DIFF
--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -11,6 +11,10 @@ but specify `output: govdown::govdown_document` instead of `output:
 html_document` in the YAML metadata of the document, or in the `_site.yml` file
 of the website.
 
+> You can't publish govdown documents on the GOV.UK website itself. Please
+> follow the normal guidance for [how to publish on
+> GOV.UK](https://www.gov.uk/guidance/how-to-publish-on-gov-uk).
+
 ## Examples
 
 These websites and documents use govdown.


### PR DESCRIPTION
People have been unsure about whether govdown documents can be submitted to the GOV.UK website for publication.  They can't -- although that would be nice -- so the usual process must be followed.  One day GOV.UK might support other ways to submit content.