### PR TITLE
Set the default to a nicer font family stack

### DIFF
--- a/install-govuk-frontend.sh
+++ b/install-govuk-frontend.sh
@@ -26,7 +26,7 @@ sassc scss/govuk.scss inst/rmarkdown/resources/govuk.css
 # the top of the file, they won't be reassigned by the later definitions.
 TYPFILE=./node_modules/govuk-frontend/govuk/settings/_typography-font.scss
 TEMPFILE=/tmp/out
-echo '$govuk-font-family: sans-serif !default;' | cat - $TYPFILE > $TEMPFILE && mv $TEMPFILE $TYPFILE
+echo '$govuk-font-family: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif !default;' | cat - $TYPFILE > $TEMPFILE && mv $TEMPFILE $TYPFILE
 echo '$govuk-font-family-tabular: false !default;' | cat - $TYPFILE > $TEMPFILE && mv $TEMPFILE $TYPFILE
 
 # Recompile the scss to css


### PR DESCRIPTION
This is the stack we use in other projects, in some operating systems you end up with a nicer font being rendered since sans-serif can default to something else.

Some more reading on system font stacks vs sans-serif: https://css-tricks.com/snippets/css/system-font-stack/

If you're not into this idea, feel free to close, no worries :)