### PR TITLE
Fix pandoc warning about missing title elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # govdown 0.9.0
 
+* Fix a pandoc warning about missing title elements.
+
 # govdown 0.8.0
 
 * Upgrade to GOV.UK Frontend release v3.4.0.  Some user-facing changes, see the

--- a/R/govdown-format.R
+++ b/R/govdown-format.R
@@ -218,6 +218,7 @@ govdown_document <- function(keep_md = FALSE,
                         "--lua-filter", govuk_lua,
                         "--lua-filter", highlight_lua,
                         "--resource-path", resources,
+                        paste0("--metadata=title:", title),
                         "--no-highlight",
                         "--mathjax"
                         ),


### PR DESCRIPTION
All it needed was the title to be passed into a `--metadata`  argument.