### PR TITLE
unstrap() for crosstalk interference (fix #57)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # govdown 0.9.0
 
 * Fix a pandoc warning about missing title elements.
+* Provide `unstrap()` to remove unwanted Boostrap CSS from any crosstalk
+    components (#57)
 
 # govdown 0.8.0
 

--- a/R/unstrap.R
+++ b/R/unstrap.R
@@ -1,0 +1,34 @@
+#' Remove bootstrap css from crosstalk components
+#'
+#' If your page renders weirdly, it might be because a crosstalk component like
+#' [`crosstalk::filter_select()`] is injecting unexpected css into
+#' your page, which happens because they try to use the Bootstrap css library by
+#' default.  The `unstrap()` function prevents that from happening.
+#'
+#' @param x a crosstalk component, such as [`crosstalk::filter_select()`]
+#'
+#' @return
+#'
+#' The component `x` but with any `"boostrap"` dependency removed from its
+#' `html_dependencies` attribute.
+#'
+#' @examples
+#' # The fs object will inject css into your page.
+#' fs <- crosstalk::filter_select(
+#'     id = "myselector",
+#'     label = "select something",
+#'     sharedData = df,
+#'     group = ~selection_column
+#'   )
+#'
+#' # The fs_nobootstrap object won't inject css into your page.
+#' fs_nobootstrap <- unstrap(fs)
+#' @export
+unstrap <- function(x) {
+  attr(x, "html_dependencies") <-
+    Filter(
+      function(dependency) {dependency$name != "bootstrap"},
+      attr(x, "html_dependencies")
+    )
+  x
+}

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -51,6 +51,12 @@ to obtain a more recent version of pandoc.
 If you are developing a Shiny application, then look at
 https://github.com/moj-analytical-services/shinyGovstyle.
 
+## Crosstalk
+
+If you use the [crosstalk](https://rstudio.github.io/crosstalk/) package for
+interactive commponents, then use the `govdown::unstrap()` function to prevent
+them from interfering with how the page is rendered.
+
 ## Creating standalone HTML pages
 
 Govdown HTML pages are created in the same way as R Markdown HTML pages.  Write


### PR DESCRIPTION
Crosstalk components inject Bootstrap CSS, which interferes with the existing
GOV.UK Frontent CSS.  `unstrap()` strips an attribute from the component, to
prevent this happening.