### PR TITLE
Remove inclusion of title into page content

### DIFF
--- a/inst/rmarkdown/resources/govuk.html
+++ b/inst/rmarkdown/resources/govuk.html
@@ -69,9 +69,6 @@ window.onload = function() {
 
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper " id="main-content" role="main">
-      $if(title)$
-      <h1 class="govuk-heading-xl">$title$</h1>
-      $endif$
       $body$
     </main>
   </div>


### PR DESCRIPTION
🤞 this corrects problem resulting from #58 which results in the `title` piece of YAML front-matter getting inserted as a title in the main page content.