### PR TITLE
Fix syntax of verbatim R Markdown R code chunks

### DIFF
--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -495,8 +495,6 @@ Or specify an R Markdown R code chunk with the option `eval=FALSE` as follows.
 ```{r eval=FALSE}`r ''`
 print("This code will not be evaluated")
 ```
-Python code chunks also work, as do any of the languages supported by knitr.
-
 ````
 Create code chunks that are to be evaluated as follows (of course you can also explicitly set chunk option `eval=TRUE`).
 ````
@@ -504,6 +502,13 @@ Create code chunks that are to be evaluated as follows (of course you can also e
 print("This code will be evaluated")
 ```
 ````
+Python code chunks also work (as long as you have the reticulate package and Python installed), as do any of the languages supported by knitr. For example, 
+````
+```{python}`r ''`
+'Monty Python'.split()
+```
+````
+produces the following.
 ```{python}
 'Monty Python'.split()
 ```

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -489,12 +489,6 @@ Create code chunks that are not to be evaluated using a plain markdown R code ch
 ```r
 print("This code will not be evaluated")
 ```
-Create code chunks that are to be evaluated as follows.
-
-```md
-    ```{r}
-    print("This code will be evaluated")
-    ```
 ````
 Or specify an R Markdown R code chunk with the option `eval=FALSE` as follows.
 ````
@@ -503,6 +497,12 @@ print("This code will not be evaluated")
 ```
 Python code chunks also work, as do any of the languages supported by knitr.
 
+````
+Create code chunks that are to be evaluated as follows (of course you can also explicitly set chunk option `eval=TRUE`).
+````
+```{r}`r ''`
+print("This code will be evaluated")
+```
 ````
 ```{python}
 'Monty Python'.split()

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -485,10 +485,9 @@ print("This code will be evaluated")
 ```
 Create code chunks that are not to be evaluated using a plain markdown R code chunk as follows.
 
-```md
-    ```r
-    print("This code will not be evaluated")
-    ```
+````
+```r
+print("This code will not be evaluated")
 ```
 Create code chunks that are to be evaluated as follows.
 
@@ -496,6 +495,7 @@ Create code chunks that are to be evaluated as follows.
     ```{r}
     print("This code will be evaluated")
     ```
+````
 ```
 Python code chunks also work, as do any of the languages supported by knitr.
 

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -483,7 +483,7 @@ print("This code will not be evaluated")
 ```{r}
 print("This code will be evaluated")
 ```
-Create code chunks that are not to be evaluated as follows.
+Create code chunks that are not to be evaluated using a plain markdown R code chunk as follows.
 
 ```md
     ```r

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -496,9 +496,14 @@ Create code chunks that are to be evaluated as follows.
     print("This code will be evaluated")
     ```
 ````
+Or specify an R Markdown R code chunk with the option `eval=FALSE` as follows.
+````
+```{r eval=FALSE}`r ''`
+print("This code will not be evaluated")
 ```
 Python code chunks also work, as do any of the languages supported by knitr.
 
+````
 ```{python}
 'Monty Python'.split()
 ```

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -518,6 +518,8 @@ Images use the normal markdown syntax.
 
 ![caption text](./favicon/apple-touch-icon-180x180.png)
 
+Or you can use the `knitr::include_graphics()` function in an R Markdown R code chunk.
+
 ### Tables
 
 All four kinds of [pandoc tables](https://pandoc.org/MANUAL.html#tables) are

--- a/site/index.Rmd
+++ b/site/index.Rmd
@@ -61,7 +61,7 @@ them from interfering with how the page is rendered.
 ## Creating standalone HTML pages
 
 Govdown HTML pages are created in the same way as R Markdown HTML pages.  Write
-a markdown document (a plain text file with the suffix `.Rmd` or `.md` instead
+a markdown document (a plain text file with the suffix `.Rmd` instead
 of `.txt`), and put something called 'YAML metadata' at the top.  It should look
 like this:
 
@@ -93,7 +93,7 @@ domain.
 ## Creating websites
 
 Websites are created in the same way as R Markdown websites.  Write
-a set of markdown documents (plain text files with the suffix `.Rmd` or `.md` instead
+a set of markdown documents (plain text files with the suffix `.Rmd` instead
 of `.txt`), and a configuration file called `_site.yml` with content like the
 following:
 


### PR DESCRIPTION
A very impressive package.

I noticed that you are not displaying the intended verbatim R Markdown R code chunks correctly, e.g. this was incorrect.
<img width="392" alt="rmd-r-code-chunk-verbatim-error" src="https://user-images.githubusercontent.com/3777473/104120972-d14eba80-5332-11eb-9046-55dd7d5546c8.png">

I have fixed that, and made a few other minor suggestions.

There are several ways to include verbatim R Markdown code chunks as described [here](https://rmarkdown.rstudio.com/articles_verbatim.html), [here](https://bookdown.org/yihui/rmarkdown-cookbook/verbatim-code-chunks.html), and [here](https://support.rstudio.com/hc/en-us/articles/360018181633-Including-verbatim-R-code-chunks-inside-R-Markdown).

